### PR TITLE
Add quotation of wasm-pack CLI arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,8 @@ async function init() {
     cratesMap.set(rswCrate, outDir);
   });
 
-  spawnSync(`npm`, ['link', ...Array.from(cratesMap.values())], {
+  const cratePaths = Array.from(cratesMap.values()).map(p => `'${p}'`);
+  spawnSync(`npm`, ['link', ...cratePaths], {
     shell: true,
     cwd: process.cwd(),
     stdio: 'inherit',

--- a/index.js
+++ b/index.js
@@ -78,9 +78,9 @@ async function init() {
       pkgName = rswCrate;
     }
 
-    args.push('--out-name', pkgName);
-    if (scope) args.push('--scope', scope);
-    if (outDir) args.push('--out-dir', outDir);
+    args.push('--out-name', `'${pkgName}'`);
+    if (scope) args.push('--scope', `'${scope}'`);
+    if (outDir) args.push('--out-dir', `'${outDir}'`);
 
     const cmdCwd = path.resolve(process.cwd(), rswCrate);
 


### PR DESCRIPTION
Related to [PR #21](https://github.com/lencx/vite-plugin-rsw/pull/21) of the `vite-plugin-rsw` package. Both contain the same bug where the output path is not quoted and thus interpreted as separate arguments when the cwd contains whitespaces.

I've sent the same change PR to both projects, this one has been confirmed and it fixes the issue documented in [Issue #20](https://github.com/lencx/vite-plugin-rsw/issues/20) of the `vite-plugin-rsw`. Regardless, it would probably make sense to keep both consistent and merge both PRs as the other code will probably be called in a way I can't yet comprehend 🙈